### PR TITLE
高级货币抽卡系统功能以及常用命令别名的扩展

### DIFF
--- a/core/repositories/sqlite_inventory_repo.py
+++ b/core/repositories/sqlite_inventory_repo.py
@@ -172,25 +172,25 @@ class SqliteInventoryRepository(AbstractInventoryRepository):
             return self._row_to_rod_instance(row) if row else None
 
     def clear_user_rod_instances(self, user_id: str) -> None:
-        """清空用户的所有未装备和非五星的钓竿实例"""
+        """清空用户的所有未装备且小于5星的钓竿实例"""
         with self._get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
                 DELETE FROM user_rods
-                WHERE user_id = ? AND is_equipped = 0 AND rod_id NOT IN (
-                    SELECT rod_id FROM rods WHERE rarity = 5
+                WHERE user_id = ? AND is_equipped = 0 AND rod_id IN (
+                    SELECT rod_id FROM rods WHERE rarity < 5
                 )
             """, (user_id,))
             conn.commit()
 
     def clear_user_accessory_instances(self, user_id: str) -> None:
-        """清空用户的所有未装备和非五星的配件实例"""
+        """清空用户的所有未装备且小于5星的配件实例"""
         with self._get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
                 DELETE FROM user_accessories
-                WHERE user_id = ? AND is_equipped = 0 AND accessory_id NOT IN (
-                    SELECT accessory_id FROM accessories WHERE rarity = 5
+                WHERE user_id = ? AND is_equipped = 0 AND accessory_id IN (
+                    SELECT accessory_id FROM accessories WHERE rarity < 5
                 )
             """, (user_id,))
             conn.commit()

--- a/draw/help.py
+++ b/draw/help.py
@@ -4,8 +4,8 @@ from PIL import Image, ImageDraw, ImageFont, ImageFilter
 
 
 def draw_help_image():
-    # 画布尺寸
-    width, height = 800, 2800
+    # 画布宽度（高度将自适应计算）
+    width = 800
 
     # 1. 创建渐变背景
     def create_vertical_gradient(w, h, top_color, bottom_color):
@@ -23,8 +23,6 @@ def draw_help_image():
 
     bg_top = (240, 248, 255)  # 浅蓝
     bg_bot = (255, 255, 255)  # 白
-    image = create_vertical_gradient(width, height, bg_top, bg_bot)
-    draw = ImageDraw.Draw(image)
 
     # 2. 加载字体
     def load_font(name, size):
@@ -47,9 +45,11 @@ def draw_help_image():
     line_color = (200, 200, 200)
     shadow_color = (0, 0, 0, 80)
 
-    # 4. 获取文本尺寸的辅助函数
-    def get_text_size(text, font):
-        bbox = draw.textbbox((0, 0), text, font=font)
+    # 4. 获取文本尺寸的辅助函数（测量版）
+    _measure_img = Image.new('RGB', (10, 10), bg_bot)
+    _measure_draw = ImageDraw.Draw(_measure_img)
+    def measure_text_size(text, font):
+        bbox = _measure_draw.textbbox((0, 0), text, font=font)
         return bbox[2] - bbox[0], bbox[3] - bbox[1]
 
     # 5. 处理logo背景色的函数
@@ -72,44 +72,11 @@ def draw_help_image():
         img.putdata(new_data)
         return img
 
-    # 6. 绘制 Logo 和 标题
-    logo_size = 160  # 增加logo尺寸
+    # 6. Logo/标题布局（先定义数值，稍后绘制）
+    logo_size = 160
     logo_x = 30
     logo_y = 25
-
-    try:
-        logo = Image.open(os.path.join(os.path.dirname(__file__), "resource", "astrbot_logo.jpg"))
-
-        # 将白色背景替换为与画布背景一致的颜色
-        logo = replace_white_background(logo, bg_top)
-
-        # 保持纵横比调整大小
-        logo.thumbnail((logo_size, logo_size), Image.Resampling.LANCZOS)
-
-        # 创建圆角遮罩
-        mask = Image.new("L", logo.size, 0)
-        mask_draw = ImageDraw.Draw(mask)
-        mask_draw.rounded_rectangle([0, 0, logo.size[0], logo.size[1]], 20, fill=255)
-
-        # 应用圆角遮罩
-        output = Image.new("RGBA", logo.size, (0, 0, 0, 0))
-        output.paste(logo, (0, 0))
-        output.putalpha(mask)
-
-        # 贴到主图上
-        image.paste(output, (logo_x, logo_y), output)
-
-    except Exception as e:
-        print(f"Logo加载失败: {e}")
-        # 如果没有logo文件，绘制一个圆角占位符
-        draw.rounded_rectangle((logo_x, logo_y, logo_x + logo_size, logo_y + logo_size),
-                               20, fill=bg_top, outline=(180, 180, 180), width=2)
-        draw.text((logo_x + logo_size // 2, logo_y + logo_size // 2), "LOGO",
-                  fill=(120, 120, 120), font=subtitle_font, anchor="mm")
-
-    # 主标题居中显示，调整位置避免与logo重叠
     title_y = logo_y + logo_size // 2
-    draw.text((width // 2, title_y), "钓鱼游戏帮助", fill=title_color, font=title_font, anchor="mm")
 
     # 7. 圆角矩形＋阴影 helper
     def draw_card(x0, y0, x1, y1, radius=12):
@@ -183,7 +150,8 @@ def draw_help_image():
         ("使用鱼饵 [ID]", "使用鱼饵"),
         ("使用饰品 [ID]", "使用饰品"),
         ("精炼饰品 [ID]", "精炼饰品"),
-        ("金币", "查看用户\n金币信息")
+        ("金币", "查看用户\n金币信息"),
+        ("高级货币", "查看用户\n高级货币")
     ]
 
     market = [
@@ -227,11 +195,67 @@ def draw_help_image():
         ("修改金币 [用户ID] [金币数]", "将用户的金币修改为金币数"),
         ("奖励金币 [用户ID] [金币数]", "奖励用户金币"),
         ("扣除金币 [用户ID] [金币数]", "扣除用户金币"),
+        ("修改高级货币 [用户ID] [数量]", "将用户的高级货币修改为数量"),
+        ("奖励高级货币 [用户ID] [数量]", "奖励用户高级货币"),
+        ("扣除高级货币 [用户ID] [数量]", "扣除用户高级货币"),
+        ("全体奖励金币 [数量]", "给全体用户\n发放金币"),
+        ("全体奖励高级货币 [数量]", "给全体用户\n发放高级货币"),
+        ("全体扣除金币 [数量]", "从全体用户\n扣除金币"),
+        ("全体扣除高级货币 [数量]", "从全体用户\n扣除高级货币"),
         ("开启钓鱼后台管理", "开启钓鱼后台管理"),
         ("关闭钓鱼后台管理", "关闭钓鱼后台管理")
     ]
 
-    # 10. 绘制各个部分 - 调整起始位置给logo留足空间
+    # 10. 先计算自适应高度
+    def section_delta(item_count: int, cols: int) -> int:
+        rows = math.ceil(item_count / cols) if item_count > 0 else 0
+        # 与 draw_section 中的垂直占位保持一致：h//2+25 起始 + rows*(card_h+pad) + 35
+        _, h = measure_text_size("标题", section_font)
+        card_h = 85
+        pad = 15
+        return (h // 2 + 25) + rows * (card_h + pad) + 35
+
+    y0_est = logo_y + logo_size + 30
+    y0_est += section_delta(len(basic), 3)
+    y0_est += section_delta(len(inventory), 3)
+    y0_est += section_delta(len(market), 3)
+    y0_est += section_delta(len(gacha), 3)
+    y0_est += section_delta(len(social), 2)
+    y0_est += section_delta(len(admin), 2)
+    footer_y_est = y0_est + 20
+    final_height = footer_y_est + 30
+
+    # 用最终高度创建画布，然后进行真正绘制
+    image = create_vertical_gradient(width, final_height, bg_top, bg_bot)
+    draw = ImageDraw.Draw(image)
+
+    # 绘制 Logo 和 标题
+    try:
+        logo = Image.open(os.path.join(os.path.dirname(__file__), "resource", "astrbot_logo.jpg"))
+        logo = replace_white_background(logo, bg_top)
+        logo.thumbnail((logo_size, logo_size), Image.Resampling.LANCZOS)
+        mask = Image.new("L", logo.size, 0)
+        mask_draw = ImageDraw.Draw(mask)
+        mask_draw.rounded_rectangle([0, 0, logo.size[0], logo.size[1]], 20, fill=255)
+        output = Image.new("RGBA", logo.size, (0, 0, 0, 0))
+        output.paste(logo, (0, 0))
+        output.putalpha(mask)
+        image.paste(output, (logo_x, logo_y), output)
+    except Exception as e:
+        # 如果没有logo文件，绘制一个圆角占位符
+        draw.rounded_rectangle((logo_x, logo_y, logo_x + logo_size, logo_y + logo_size),
+                               20, fill=bg_top, outline=(180, 180, 180), width=2)
+        draw.text((logo_x + logo_size // 2, logo_y + logo_size // 2), "LOGO",
+                  fill=(120, 120, 120), font=subtitle_font, anchor="mm")
+
+    draw.text((width // 2, title_y), "钓鱼游戏帮助", fill=title_color, font=title_font, anchor="mm")
+
+    # 重新基于真实 draw 定义尺寸函数
+    def get_text_size(text, font):
+        bbox = draw.textbbox((0, 0), text, font=font)
+        return bbox[2] - bbox[0], bbox[3] - bbox[1]
+
+    # 10+. 按顺序绘制各个部分
     y0 = logo_y + logo_size + 30
     y0 = draw_section("🎣 基础与核心玩法", basic, y0, cols=3)
     y0 = draw_section("🎒 背包与资产管理", inventory, y0, cols=3)
@@ -245,9 +269,9 @@ def draw_help_image():
     draw.text((width // 2, footer_y), "💡 提示：命令中的 [ID] 表示必填参数，<> 表示可选参数",
               fill=(120, 120, 120), font=desc_font, anchor="mm")
 
-    # 11. 裁剪图像到实际内容高度并保存
+    # 11. 保存（高度已自适应，无需再次裁剪）
     final_height = footer_y + 30
-    image = image.crop((0, 0, width, min(final_height, height)))
+    image = image.crop((0, 0, width, final_height))
 
     output_path = "fishing_commands_beautiful.png"
     image.save(output_path, quality=95)

--- a/draw/state.py
+++ b/draw/state.py
@@ -178,14 +178,14 @@ def draw_state_image(user_data: Dict[str, Any]) -> Image.Image:
     # 金币
     coins = user_data.get('coins', 0)
     coins_text = f"金币: {coins:,}"
-    draw.text((col1_x, row2_y), coins_text, font=small_font, fill=gold_color)
+    draw.text((col1_x, row2_y - 12), coins_text, font=small_font, fill=gold_color)
     
     # 高级货币（另起一行，避免与右侧“钓鱼次数”重叠）
     if 'premium_currency' in user_data:
         premium = user_data.get('premium_currency', 0)
         premium_text = f"高级货币: {premium:,}"
-        # 另起新行显示（卡片高度85，row2_y+24 仍在卡片内）
-        draw.text((col1_x, row2_y + 24), premium_text, font=small_font, fill=primary_light)
+        # 另起新行显示并整体上移，避免超出白色卡片底部
+        draw.text((col1_x, row2_y + 8), premium_text, font=small_font, fill=primary_light)
     
     # 钓鱼次数 - 调整列位置以均分
     total_fishing = user_data.get('total_fishing_count', 0)

--- a/draw/state.py
+++ b/draw/state.py
@@ -180,12 +180,12 @@ def draw_state_image(user_data: Dict[str, Any]) -> Image.Image:
     coins_text = f"金币: {coins:,}"
     draw.text((col1_x, row2_y), coins_text, font=small_font, fill=gold_color)
     
-    # 高级货币（显示在金币右侧）
+    # 高级货币（另起一行，避免与右侧“钓鱼次数”重叠）
     if 'premium_currency' in user_data:
         premium = user_data.get('premium_currency', 0)
-        coins_w = get_text_size(coins_text, small_font)[0]
-        premium_text = f"  高级货币: {premium:,}"
-        draw.text((col1_x + coins_w + 12, row2_y), premium_text, font=small_font, fill=primary_light)
+        premium_text = f"高级货币: {premium:,}"
+        # 另起新行显示（卡片高度85，row2_y+24 仍在卡片内）
+        draw.text((col1_x, row2_y + 24), premium_text, font=small_font, fill=primary_light)
     
     # 钓鱼次数 - 调整列位置以均分
     total_fishing = user_data.get('total_fishing_count', 0)

--- a/draw/state.py
+++ b/draw/state.py
@@ -6,6 +6,13 @@ import requests
 from io import BytesIO
 import time
 
+def format_rarity_display(rarity: int) -> str:
+    """格式化稀有度显示，支持显示到10星，10星以上显示为★★★★★★★★★★+"""
+    if rarity <= 10:
+        return '★' * rarity
+    else:
+        return '★★★★★★★★★★+'
+
 def draw_state_image(user_data: Dict[str, Any]) -> Image.Image:
     """
     绘制用户状态图像
@@ -228,7 +235,7 @@ def draw_state_image(user_data: Dict[str, Any]) -> Image.Image:
         rarity = current_rod.get('rarity', 1)
         refined_level = current_rod.get('refine_level', 1)
         star_color = rare_color if (rarity > 4 and refined_level > 4) else warning_color if rarity > 3 else text_secondary
-        draw.text((left_col_x, equipment_row3_y), f"{'★' * min(rarity, 5)} Lv.{refined_level}", font=tiny_font, fill=star_color)
+        draw.text((left_col_x, equipment_row3_y), f"{format_rarity_display(rarity)} Lv.{refined_level}", font=tiny_font, fill=star_color)
     else:
         draw.text((left_col_x, equipment_row2_y), "未装备", font=content_font, fill=text_muted)
 
@@ -243,7 +250,7 @@ def draw_state_image(user_data: Dict[str, Any]) -> Image.Image:
         rarity = current_accessory.get('rarity', 1)
         refined_level = current_accessory.get('refine_level', 1)
         star_color = rare_color if (rarity > 4 and refined_level > 4) else warning_color if rarity > 3 else text_secondary
-        draw.text((left_col_x, equipment_row6_y), f"{'★' * min(rarity, 5)} Lv.{refined_level}", font=tiny_font, fill=star_color)
+        draw.text((left_col_x, equipment_row6_y), f"{format_rarity_display(rarity)} Lv.{refined_level}", font=tiny_font, fill=star_color)
     else:
         draw.text((left_col_x, equipment_row5_y), "未装备", font=content_font, fill=text_muted)
 
@@ -266,7 +273,7 @@ def draw_state_image(user_data: Dict[str, Any]) -> Image.Image:
         draw.text((right_col_x, equipment_row2_y), bait_name, font=content_font, fill=text_primary)
         rarity = current_bait.get('rarity', 1)
         star_color = rare_color if rarity > 4 else warning_color if rarity >= 3 else text_secondary
-        bait_detail = f"{'★' * min(rarity, 5)} 剩余：{current_bait.get('quantity', 0)}"
+        bait_detail = f"{format_rarity_display(rarity)} 剩余：{current_bait.get('quantity', 0)}"
         draw.text((right_col_x, equipment_row3_y), bait_detail, font=tiny_font, fill=star_color)
     else:
         draw.text((right_col_x, equipment_row2_y), "未使用", font=content_font, fill=text_muted)

--- a/draw/state.py
+++ b/draw/state.py
@@ -180,6 +180,13 @@ def draw_state_image(user_data: Dict[str, Any]) -> Image.Image:
     coins_text = f"金币: {coins:,}"
     draw.text((col1_x, row2_y), coins_text, font=small_font, fill=gold_color)
     
+    # 高级货币（显示在金币右侧）
+    if 'premium_currency' in user_data:
+        premium = user_data.get('premium_currency', 0)
+        coins_w = get_text_size(coins_text, small_font)[0]
+        premium_text = f"  高级货币: {premium:,}"
+        draw.text((col1_x + coins_w + 12, row2_y), premium_text, font=small_font, fill=primary_light)
+    
     # 钓鱼次数 - 调整列位置以均分
     total_fishing = user_data.get('total_fishing_count', 0)
     fishing_text = f"钓鱼次数: {total_fishing:,}"
@@ -549,6 +556,7 @@ def get_user_state_data(user_repo, inventory_repo, item_template_repo, log_repo,
         'user_id': user.user_id,
         'nickname': user.nickname or user.user_id,
         'coins': user.coins,
+        'premium_currency': getattr(user, 'premium_currency', 0),
         'current_rod': current_rod,
         'current_accessory': current_accessory,
         'current_bait': current_bait,

--- a/main.py
+++ b/main.py
@@ -543,7 +543,7 @@ class FishingPlugin(Star):
 
     # ===========商店与市场==========
 
-    @filter.command("全部卖出")
+    @filter.command("全部卖出", alias={"全部出售", "卖出全部", "出售全部", "卖光", "清空鱼", "一键卖出"})
     async def sell_all(self, event: AstrMessageEvent):
         """卖出用户所有鱼"""
         user_id = event.get_sender_id()
@@ -553,7 +553,7 @@ class FishingPlugin(Star):
         else:
             yield event.plain_result("❌ 出错啦！请稍后再试。")
 
-    @filter.command("保留卖出")
+    @filter.command("保留卖出", alias={"保留出售", "卖出保留", "出售保留", "留一卖出", "卖鱼留一"})
     async def sell_keep(self, event: AstrMessageEvent):
         """卖出用户鱼，但保留每种鱼一条"""
         user_id = event.get_sender_id()
@@ -563,7 +563,7 @@ class FishingPlugin(Star):
         else:
             yield event.plain_result("❌ 出错啦！请稍后再试。")
 
-    @filter.command("出售稀有度")
+    @filter.command("出售稀有度", alias={"按稀有度出售", "稀有度出售", "卖稀有度", "出售星级", "按星级出售"})
     async def sell_by_rarity(self, event: AstrMessageEvent):
         """按稀有度出售鱼"""
         user_id = event.get_sender_id()
@@ -581,7 +581,7 @@ class FishingPlugin(Star):
         else:
             yield event.plain_result("❌ 出错啦！请稍后再试。")
 
-    @filter.command("出售鱼竿")
+    @filter.command("出售鱼竿", alias={"卖出鱼竿", "卖鱼竿", "卖掉鱼竿"})
     async def sell_rod(self, event: AstrMessageEvent):
         """出售鱼竿"""
         user_id = event.get_sender_id()
@@ -603,7 +603,7 @@ class FishingPlugin(Star):
             yield event.plain_result("❌ 出错啦！请稍后再试。")
 
     # 批量删除用户鱼竿
-    @filter.command("出售所有鱼竿", alias={ "出售全部鱼竿" })
+    @filter.command("出售所有鱼竿", alias={"出售全部鱼竿", "卖出所有鱼竿", "卖出全部鱼竿", "卖光鱼竿", "清空鱼竿", "一键卖鱼竿"})
     async def sell_all_rods(self, event: AstrMessageEvent):
         """出售用户所有鱼竿"""
         user_id = event.get_sender_id()
@@ -613,7 +613,7 @@ class FishingPlugin(Star):
         else:
             yield event.plain_result("❌ 出错啦！请稍后再试。")
 
-    @filter.command("出售饰品")
+    @filter.command("出售饰品", alias={"卖出饰品", "卖饰品", "卖掉饰品"})
     async def sell_accessories(self, event: AstrMessageEvent):
         """出售饰品"""
         user_id = event.get_sender_id()
@@ -634,7 +634,7 @@ class FishingPlugin(Star):
         else:
             yield event.plain_result("❌ 出错啦！请稍后再试。")
 
-    @filter.command("出售所有饰品", alias={ "出售全部饰品" })
+    @filter.command("出售所有饰品", alias={"出售全部饰品", "卖出所有饰品", "卖出全部饰品", "卖光饰品", "清空饰品", "一键卖饰品"})
     async def sell_all_accessories(self, event: AstrMessageEvent):
         """出售用户所有饰品"""
         user_id = event.get_sender_id()

--- a/main.py
+++ b/main.py
@@ -1409,6 +1409,74 @@ class FishingPlugin(Star):
             self.user_repo.update(user)
             updated += 1
         yield event.plain_result(f"✅ 已向 {updated} 位用户每人发放 {amount_int} 高级货币")
+
+    @filter.permission_type(PermissionType.ADMIN)
+    @filter.command("全体扣除金币")
+    async def deduct_all_coins(self, event: AstrMessageEvent):
+        """从所有注册用户扣除金币（不低于0）"""
+        args = event.message_str.split(" ")
+        if len(args) < 2:
+            yield event.plain_result("❌ 请指定扣除的金币数量，例如：/全体扣除金币 1000")
+            return
+        amount = args[1]
+        if not amount.isdigit() or int(amount) <= 0:
+            yield event.plain_result("❌ 扣除数量必须是正整数，请检查后重试。")
+            return
+        amount_int = int(amount)
+        user_ids = self.user_repo.get_all_user_ids()
+        if not user_ids:
+            yield event.plain_result("❌ 当前没有注册用户。")
+            return
+        affected = 0
+        total_deducted = 0
+        for uid in user_ids:
+            user = self.user_repo.get_by_id(uid)
+            if not user:
+                continue
+            if user.coins <= 0:
+                continue
+            deduct = amount_int if user.coins >= amount_int else user.coins
+            if deduct <= 0:
+                continue
+            user.coins -= deduct
+            self.user_repo.update(user)
+            affected += 1
+            total_deducted += deduct
+        yield event.plain_result(f"✅ 已从 {affected} 位用户总计扣除 {total_deducted} 金币（每人至多 {amount_int}）")
+
+    @filter.permission_type(PermissionType.ADMIN)
+    @filter.command("全体扣除高级货币")
+    async def deduct_all_premium(self, event: AstrMessageEvent):
+        """从所有注册用户扣除高级货币（不低于0）"""
+        args = event.message_str.split(" ")
+        if len(args) < 2:
+            yield event.plain_result("❌ 请指定扣除的高级货币数量，例如：/全体扣除高级货币 100")
+            return
+        amount = args[1]
+        if not amount.isdigit() or int(amount) <= 0:
+            yield event.plain_result("❌ 扣除数量必须是正整数，请检查后重试。")
+            return
+        amount_int = int(amount)
+        user_ids = self.user_repo.get_all_user_ids()
+        if not user_ids:
+            yield event.plain_result("❌ 当前没有注册用户。")
+            return
+        affected = 0
+        total_deducted = 0
+        for uid in user_ids:
+            user = self.user_repo.get_by_id(uid)
+            if not user:
+                continue
+            if user.premium_currency <= 0:
+                continue
+            deduct = amount_int if user.premium_currency >= amount_int else user.premium_currency
+            if deduct <= 0:
+                continue
+            user.premium_currency -= deduct
+            self.user_repo.update(user)
+            affected += 1
+            total_deducted += deduct
+        yield event.plain_result(f"✅ 已从 {affected} 位用户总计扣除 {total_deducted} 高级货币（每人至多 {amount_int}）")
     @filter.permission_type(PermissionType.ADMIN)
     @filter.command("奖励金币")
     async def reward_coins(self, event: AstrMessageEvent):

--- a/main.py
+++ b/main.py
@@ -313,7 +313,7 @@ class FishingPlugin(Star):
             for rarity in sorted(fished_by_rarity.keys(), reverse=True):
                 fish_list = fished_by_rarity[rarity]
                 if fish_list:
-                    message += f"\n {'⭐' * rarity } 稀有度 {rarity}：\n"
+                    message += f"\n {format_rarity_display(rarity)} 稀有度 {rarity}：\n"
                     for fish in fish_list:
                         message += f"  - {fish['name']} x  {fish['quantity']} （{fish['base_value']}金币 / 个） \n"
             message += f"\n🐟 总鱼数：{pond_fish['stats']['total_count']} 条\n"
@@ -394,7 +394,7 @@ class FishingPlugin(Star):
             # 构造输出信息,附带emoji
             message = "【🐟 鱼饵】：\n"
             for bait in bait_info["baits"]:
-                message += f" - {bait['name']} x {bait['quantity']} (稀有度: {'⭐' * bait['rarity']})\n"
+                message += f" - {bait['name']} x {bait['quantity']} (稀有度: {format_rarity_display(bait['rarity'])})\n"
                 message += f"   - ID: {bait['bait_id']}\n"
                 if bait["duration_minutes"] > 0:
                     message += f"   - 持续时间: {bait['duration_minutes']} 分钟\n"

--- a/main.py
+++ b/main.py
@@ -527,7 +527,7 @@ class FishingPlugin(Star):
         user_id = event.get_sender_id()
         user = self.user_repo.get_by_id(user_id)
         if user:
-            yield event.plain_result(f"💰 金币：{user.coins} ｜ 💎 高级货币：{user.premium_currency}")
+            yield event.plain_result(f"💰 您的金币余额：{user.coins} 金币")
         else:
             yield event.plain_result("❌ 您还没有注册，请先使用 /注册 命令注册。")
 

--- a/main.py
+++ b/main.py
@@ -1355,6 +1355,60 @@ class FishingPlugin(Star):
         user.premium_currency -= int(premium)
         self.user_repo.update(user)
         yield event.plain_result(f"✅ 成功扣除用户 {target_user_id} 的 {premium} 高级货币")
+
+    @filter.permission_type(PermissionType.ADMIN)
+    @filter.command("全体奖励金币")
+    async def reward_all_coins(self, event: AstrMessageEvent):
+        """给所有注册用户发放金币"""
+        args = event.message_str.split(" ")
+        if len(args) < 2:
+            yield event.plain_result("❌ 请指定奖励的金币数量，例如：/全体奖励金币 1000")
+            return
+        amount = args[1]
+        if not amount.isdigit() or int(amount) <= 0:
+            yield event.plain_result("❌ 奖励数量必须是正整数，请检查后重试。")
+            return
+        amount_int = int(amount)
+        user_ids = self.user_repo.get_all_user_ids()
+        if not user_ids:
+            yield event.plain_result("❌ 当前没有注册用户。")
+            return
+        updated = 0
+        for uid in user_ids:
+            user = self.user_repo.get_by_id(uid)
+            if not user:
+                continue
+            user.coins += amount_int
+            self.user_repo.update(user)
+            updated += 1
+        yield event.plain_result(f"✅ 已向 {updated} 位用户每人发放 {amount_int} 金币")
+
+    @filter.permission_type(PermissionType.ADMIN)
+    @filter.command("全体奖励高级货币")
+    async def reward_all_premium(self, event: AstrMessageEvent):
+        """给所有注册用户发放高级货币"""
+        args = event.message_str.split(" ")
+        if len(args) < 2:
+            yield event.plain_result("❌ 请指定奖励的高级货币数量，例如：/全体奖励高级货币 100")
+            return
+        amount = args[1]
+        if not amount.isdigit() or int(amount) <= 0:
+            yield event.plain_result("❌ 奖励数量必须是正整数，请检查后重试。")
+            return
+        amount_int = int(amount)
+        user_ids = self.user_repo.get_all_user_ids()
+        if not user_ids:
+            yield event.plain_result("❌ 当前没有注册用户。")
+            return
+        updated = 0
+        for uid in user_ids:
+            user = self.user_repo.get_by_id(uid)
+            if not user:
+                continue
+            user.premium_currency += amount_int
+            self.user_repo.update(user)
+            updated += 1
+        yield event.plain_result(f"✅ 已向 {updated} 位用户每人发放 {amount_int} 高级货币")
     @filter.permission_type(PermissionType.ADMIN)
     @filter.command("奖励金币")
     async def reward_coins(self, event: AstrMessageEvent):

--- a/manager/server.py
+++ b/manager/server.py
@@ -285,7 +285,17 @@ async def manage_gacha():
 async def add_gacha_pool():
     form = await request.form
     item_template_service = current_app.config["ITEM_TEMPLATE_SERVICE"]
-    item_template_service.add_pool_template(form.to_dict())
+    data = form.to_dict()
+    # 将 currency_type/cost_amount 映射到 cost_coins 或 cost_premium_currency
+    currency_type = data.get("currency_type", "coins")
+    amount = int(data.get("cost_amount", 0) or 0)
+    payload = {
+        "name": data.get("name"),
+        "description": data.get("description"),
+        "cost_coins": amount if currency_type == "coins" else 0,
+        "cost_premium_currency": amount if currency_type == "premium" else 0,
+    }
+    item_template_service.add_pool_template(payload)
     await flash("奖池添加成功！", "success")
     return redirect(url_for("admin_bp.manage_gacha"))
 
@@ -295,7 +305,16 @@ async def add_gacha_pool():
 async def edit_gacha_pool(pool_id):
     form = await request.form
     item_template_service = current_app.config["ITEM_TEMPLATE_SERVICE"]
-    item_template_service.update_pool_template(pool_id, form.to_dict())
+    data = form.to_dict()
+    currency_type = data.get("currency_type", "coins")
+    amount = int(data.get("cost_amount", 0) or 0)
+    payload = {
+        "name": data.get("name"),
+        "description": data.get("description"),
+        "cost_coins": amount if currency_type == "coins" else 0,
+        "cost_premium_currency": amount if currency_type == "premium" else 0,
+    }
+    item_template_service.update_pool_template(pool_id, payload)
     await flash(f"奖池ID {pool_id} 更新成功！", "success")
     return redirect(url_for("admin_bp.manage_gacha"))
 

--- a/manager/templates/gacha.html
+++ b/manager/templates/gacha.html
@@ -16,8 +16,11 @@
                 <h5 class="card-title">{{ pool.name }} (ID: {{ pool.gacha_pool_id }})</h5>
                 <p class="card-text">{{ pool.description or '无描述' }}</p>
                 <p>
-                    <span class="badge bg-primary">花费金币: {{ pool.cost_coins }}</span>
-                    <span class="badge bg-warning text-dark ms-2">花费高级货币: {{ pool.cost_premium_currency }}</span>
+                    {% if pool.cost_premium_currency and pool.cost_premium_currency > 0 %}
+                        <span class="badge bg-warning text-dark">花费：高级货币 {{ pool.cost_premium_currency }}</span>
+                    {% else %}
+                        <span class="badge bg-primary">花费：金币 {{ pool.cost_coins }}</span>
+                    {% endif %}
                 </p>
             </div>
             <div class="card-footer text-end">
@@ -54,9 +57,15 @@
                 <div class="modal-body">
                     <div class="mb-3"><label>名称</label><input type="text" name="name" class="form-control" required></div>
                     <div class="mb-3"><label>描述</label><textarea name="description" class="form-control" rows="2"></textarea></div>
-                    <div class="mb-3"><label>花费金币</label><input type="number" name="cost_coins" class="form-control" value="0"></div>
-                    <div class="mb-1"><label>花费高级货币</label><input type="number" name="cost_premium_currency" class="form-control" value="0"></div>
-                    <div class="form-text text-muted">若填写了高级货币，抽卡将优先消耗高级货币。</div>
+                    <div class="mb-3">
+                        <label>消耗货币</label>
+                        <select name="currency_type" class="form-select">
+                            <option value="coins">金币</option>
+                            <option value="premium">高级货币</option>
+                        </select>
+                    </div>
+                    <div class="mb-1"><label>消耗数量</label><input type="number" name="cost_amount" class="form-control" value="0"></div>
+                    <div class="form-text text-muted">卡池消耗为单一币种：金币或高级货币。</div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">关闭</button>
@@ -80,6 +89,8 @@ document.addEventListener('DOMContentLoaded', function () {
         modalTitle.textContent = '添加新奖池';
         form.action = "{{ url_for('admin_bp.add_gacha_pool') }}";
         form.reset();
+        if (form.elements['currency_type']) form.elements['currency_type'].value = 'coins';
+        if (form.elements['cost_amount']) form.elements['cost_amount'].value = 0;
     });
 
     document.querySelectorAll('.edit-btn').forEach(button => {
@@ -87,11 +98,14 @@ document.addEventListener('DOMContentLoaded', function () {
             const data = JSON.parse(this.dataset.itemJson);
             modalTitle.textContent = `编辑奖池: ${data.name}`;
             form.action = `/admin/gacha/edit/${data.gacha_pool_id}`;
-            for (const key in data) {
-                if (form.elements[key]) {
-                    form.elements[key].value = data[key] || '';
-                }
-            }
+            // 名称与描述
+            if (form.elements['name']) form.elements['name'].value = data.name || '';
+            if (form.elements['description']) form.elements['description'].value = data.description || '';
+
+            // 货币类型与金额（单选）
+            const isPremium = (data.cost_premium_currency && data.cost_premium_currency > 0);
+            if (form.elements['currency_type']) form.elements['currency_type'].value = isPremium ? 'premium' : 'coins';
+            if (form.elements['cost_amount']) form.elements['cost_amount'].value = isPremium ? (data.cost_premium_currency || 0) : (data.cost_coins || 0);
         });
     });
 });

--- a/manager/templates/gacha.html
+++ b/manager/templates/gacha.html
@@ -17,6 +17,7 @@
                 <p class="card-text">{{ pool.description or '无描述' }}</p>
                 <p>
                     <span class="badge bg-primary">花费金币: {{ pool.cost_coins }}</span>
+                    <span class="badge bg-warning text-dark ms-2">花费高级货币: {{ pool.cost_premium_currency }}</span>
                 </p>
             </div>
             <div class="card-footer text-end">
@@ -54,6 +55,8 @@
                     <div class="mb-3"><label>名称</label><input type="text" name="name" class="form-control" required></div>
                     <div class="mb-3"><label>描述</label><textarea name="description" class="form-control" rows="2"></textarea></div>
                     <div class="mb-3"><label>花费金币</label><input type="number" name="cost_coins" class="form-control" value="0"></div>
+                    <div class="mb-1"><label>花费高级货币</label><input type="number" name="cost_premium_currency" class="form-control" value="0"></div>
+                    <div class="form-text text-muted">若填写了高级货币，抽卡将优先消耗高级货币。</div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">关闭</button>

--- a/utils.py
+++ b/utils.py
@@ -52,10 +52,17 @@ def to_percentage(value: float) -> str:
     else:
         return f"{(value - 1) * 100:.2f}%"
 
+def format_rarity_display(rarity: int) -> str:
+    """格式化稀有度显示，支持显示到10星，10星以上显示为⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐+"""
+    if rarity <= 10:
+        return '⭐' * rarity
+    else:
+        return '⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐+'
+
 def format_accessory_or_rod(accessory_or_rod: dict) -> str:
     """格式化配件信息"""
     message =  f" - ID: {accessory_or_rod['instance_id']}\n"
-    message += f" - {accessory_or_rod['name']} (稀有度: {'⭐' * accessory_or_rod['rarity']})\n"
+    message += f" - {accessory_or_rod['name']} (稀有度: {format_rarity_display(accessory_or_rod['rarity'])})\n"
     if accessory_or_rod.get("is_equipped", False):
         message += f"   - {'✅ 已装备'}\n"
     if accessory_or_rod.get("bonus_fish_quality_modifier", 1.0) != 1.0 and accessory_or_rod.get("bonus_fish_quality_modifier", 1) != 1 and accessory_or_rod.get("bonus_fish_quality_modifier", 1) > 0:


### PR DESCRIPTION
## 功能概述

本次更新为钓鱼插件扩展了**高级货币 `premium_currency`抽卡系统**，允许用户使用高级货币（钻石/星石）进行抽卡，同时优化了用户界面显示和数据库清理逻辑。其次根据用户反馈，对常用卖出库存命令进行了扩展。（之前很容易错判然后触发llm，如果有更好的方法请告诉我）

## 主要变更

### 1. 高级货币抽卡支持

#### 核心功能
- **双货币系统**：抽卡池现在支持金币和高级货币两种支付方式
- **智能货币选择**：系统优先使用高级货币，如果未配置则使用金币
- **费用计算优化**：根据卡池配置自动选择相应的货币类型进行扣费

#### 代码变更
- `core/services/gacha_service.py`：重构抽卡逻辑，支持高级货币支付
- `main.py`：新增高级货币相关命令和管理功能
- `manager/server.py` 和 `manager/templates/gacha.html`：Web管理界面支持高级货币配置

### 2. 用户界面优化

#### 状态显示增强
- **高级货币显示**：用户状态面板新增高级货币余额显示
- **抽卡池信息**：抽卡命令显示卡池使用的货币类型
- **帮助文档更新**：新增高级货币相关命令说明

#### 代码变更
- `draw/state.py`：用户状态图像生成支持高级货币显示
- `draw/help.py`：帮助文档新增高级货币命令
- `main.py`：新增高级货币查看和管理命令

### 3. 数据库清理逻辑优化

#### 清理策略改进
- **精确清理**：只清理未装备且稀有度小于5星的物品
- **保护机制**：保留已装备物品和五星稀有物品
- **性能优化**：减少不必要的数据库操作

#### 代码变更
- `core/repositories/sqlite_inventory_repo.py`：优化清理逻辑，使用 `IN` 查询替代 `NOT IN`

## 新增命令

### 用户命令
- `/高级货币` - 查看用户高级货币余额
- `/钻石` - 高级货币的别名命令
- `/星石` - 高级货币的别名命令

### 管理员命令
- `/修改高级货币 [用户ID] [数量]` - 修改用户高级货币
- `/奖励高级货币 [用户ID] [数量]` - 奖励用户高级货币
- `/扣除高级货币 [用户ID] [数量]` - 扣除用户高级货币
- `/全体奖励高级货币 [数量]` - 给所有用户发放高级货币
- `/全体扣除高级货币 [数量]` - 从所有用户扣除高级货币

## 技术实现

### 抽卡系统架构
```python
# 费用计算逻辑
use_premium_currency = (getattr(pool, "cost_premium_currency", 0) or 0) > 0
total_premium_cost = (pool.cost_premium_currency or 0) * num_draws
total_coin_cost = (pool.cost_coins or 0) * num_draws

# 货币扣除逻辑
if use_premium_currency:
    user.premium_currency -= total_premium_cost
else:
    user.coins -= total_coin_cost
```

### 数据库优化
```sql
-- 优化后的清理查询
DELETE FROM user_rods
WHERE user_id = ? AND is_equipped = 0 AND rod_id IN (
    SELECT rod_id FROM rods WHERE rarity < 5
)
```

## 配置说明

### 抽卡池配置
- `cost_coins`：金币费用（传统方式）
- `cost_premium_currency`：高级货币费用（新功能）
- 系统优先使用高级货币，如果为0则使用金币

### Web管理界面
- 支持创建和编辑使用高级货币的抽卡池
- 货币类型选择：金币或高级货币
- 费用数量配置


## 未来可能会做的扩展

- 高级货币商店系统
- 货币转换功能
- 更丰富的抽卡池配置选项

---

**分支**: `premium_currency-gacha`  
**目标分支**: `main`  
**影响范围**: 抽卡系统、用户管理、Web管理界面

## 根据用户反馈的其他变更，添加了更多别名来方便用户使用。

### 1. 全部卖出鱼类命令
**原命令：** `/全部卖出`
**新增别名：** `全部出售`、`卖出全部`、`出售全部`、`卖光`、`清空鱼`、`一键卖出`

### 2. 保留卖出鱼类命令
**原命令：** `/保留卖出`
**新增别名：** `保留出售`、`卖出保留`、`出售保留`、`留一卖出`、`卖鱼留一`

### 3. 按稀有度出售鱼类命令
**原命令：** `/出售稀有度`
**新增别名：** `按稀有度出售`、`稀有度出售`、`卖稀有度`、`出售星级`、`按星级出售`

### 4. 出售单个鱼竿命令
**原命令：** `/出售鱼竿`
**新增别名：** `卖出鱼竿`、`卖鱼竿`、`卖掉鱼竿`

### 5. 出售单个饰品命令
**原命令：** `/出售饰品`
**新增别名：** `卖出饰品`、`卖饰品`、`卖掉饰品`

### 6. 出售所有鱼竿命令
**原命令：** `/出售所有鱼竿`（已有别名：`出售全部鱼竿`）
**新增别名：** `卖出所有鱼竿`、`卖出全部鱼竿`、`卖光鱼竿`、`清空鱼竿`、`一键卖鱼竿`

### 7. 出售所有饰品命令
**原命令：** `/出售所有饰品`（已有别名：`出售全部饰品`）
**新增别名：** `卖出所有饰品`、`卖出全部饰品`、`卖光饰品`、`清空饰品`、`一键卖饰品`

### 使用示例
现在用户可以使用多种方式来表达同一个命令：
- `/全部卖出` 或 `/全部出售` 或 `/卖光` 或 `/清空鱼` 等都可以卖出所有鱼
- `/保留卖出` 或 `/留一卖出` 或 `/卖鱼留一` 等都可以保留每种鱼一条后卖出
- `/出售稀有度 3` 或 `/按星级出售 3` 或 `/卖稀有度 3` 等都可以按稀有度出售鱼

## Sourcery 总结

为扭蛋系统添加高级货币层，并支持相应的命令和网页UI，增强显示和清理逻辑，并调整新功能的帮助图片生成

新功能：
- 实现双货币扭蛋抽奖，支持高级货币和金币
- 添加用户命令 (`/高级货币`, `/钻石`, `/星石`) 和管理员命令，用于修改、奖励和扣除高级货币
- 引入批量奖励和扣除命令，用于所有用户的金币和高级货币
- 扩展网页管理界面，支持货币类型选择和扭蛋池的统一成本配置

改进：
- 更新扭蛋逻辑和命令，优先使用高级货币支付并显示正确的成本类型
- 增强用户状态和帮助图片生成，动态包含高级货币并自动调整布局高度
- 优化库存清理SQL，仅删除稀有度低于五星的未装备物品

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a premium currency layer to the gacha system with corresponding commands and web UI support, enhance display and cleanup logic, and adjust help image generation for the new features

New Features:
- Implement dual-currency gacha draws supporting both premium currency and coins
- Add user commands (/高级货币, /钻石, /星石) and admin commands for modifying, rewarding, and deducting premium currency
- Introduce bulk reward and deduction commands for all users’ coins and premium currency
- Extend web management interface with currency type selection and unified cost configuration for gacha pools

Enhancements:
- Update gacha logic and commands to prioritize premium currency payment and display the correct cost type
- Enhance user state and help image generation to dynamically include premium currency and auto-adjust layout height
- Refine inventory cleanup SQL to only delete unequipped items with rarity below five stars

</details>